### PR TITLE
[Doc]: Small typo and Broken Link Fix

### DIFF
--- a/reading_images/README.md
+++ b/reading_images/README.md
@@ -16,8 +16,8 @@ The libraries that we use to read and process images are as follows:
 1. [Numpy](https://pypi.org/project/numpy/)
 2. [Matplotlib](https://pypi.org/project/matplotlib/)
 3. [OpenCV](https://pypi.org/project/opencv-python/)
-4. [Scikit-image](http://scikit-image.org/docs/dev/install.html)
-5. [ImageIO](https://imageio.readthedocs.io/en/stable/installation.html)
+4. [Scikit-image](https://pypi.org/project/scikit-image/)
+5. [ImageIO](https://pypi.org/project/imageio/)
 6. [Visvis](https://pypi.org/project/visvis/)
 - - - -
 I know, those were a lotta libraries, but hey it's just this once.

--- a/reading_images/README.md
+++ b/reading_images/README.md
@@ -4,7 +4,7 @@
 ## Reading Images ##
 
 - - - -
-So, if you have mad it till here you must be really interested in learning how a computer sees images.Let's put on our coding caps and get started. 
+So, if you have made it till here you must be really interested in learning how a computer sees images. Let's put on our coding caps and get started. 
 - - - -
 First things first, you'll need to read the image you have into your code as data. We are using Python here so I'll start with the assumption that you have python installed in your system.
 - - - -


### PR DESCRIPTION
### chapter 1 readme

---

#### Typo:
mad -> made


#### Broken Link:
Replaced broken link of `scikit-image` and `imageio` with respective PyPI Links similar to other image library given in the same readme.
